### PR TITLE
Introducing IndraHttpClient

### DIFF
--- a/indra-client/pom.xml
+++ b/indra-client/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>indra-parent</artifactId>
+        <groupId>org.lambda3</groupId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <name>Indra Client Module</name>
+
+    <artifactId>indra-client</artifactId>
+    <properties>
+        <okhttp3.version>3.6.0</okhttp3.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.lambda3</groupId>
+            <artifactId>indra-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${okhttp3.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/indra-client/src/main/java/org/lambda3/indra/client/IndraHttpClient.java
+++ b/indra-client/src/main/java/org/lambda3/indra/client/IndraHttpClient.java
@@ -1,0 +1,99 @@
+package org.lambda3.indra.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.*;
+import org.lambda3.indra.common.client.RelatednessRequest;
+import org.lambda3.indra.common.client.RelatednessResponse;
+
+import java.io.IOException;
+
+/*-
+ * ==========================License-Start=============================
+ * Indra Client Module
+ * --------------------------------------------------------------------
+ * Copyright (C) 2017 Lambda^3
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * ==========================License-End===============================
+ */
+
+/**
+ * <h3>IndraHttpClients should be shared</h3>
+ * <p>
+ * <p>It performs best when you create a single {@code IndraHttpClient} instance and reuse it for
+ * all of your calls.</p>
+ * <p>
+ * <p>Usage:</p>
+ * <pre>{@code
+ *   List<TextPair> reqTextPairs = new LinkedList<TextPair>() {{
+ *     add(new TextPair("mother", "love"));
+ *     add(new TextPair("father", "love"));
+ *   }};
+ *   RelatednessRequest request = new RelatednessRequest("wiki-2014", "W2V", "EN", reqTextPairs, ScoreFunction.COSINE);
+ *   IndraHttpClient c = new IndraHttpClient("http://localhost:8916");
+ *   RelatednessResponse resp = c.Relatedness(request);
+ *   Collection<ScoredTextPair> scored = resp.pairs;
+ * }</pre>
+ */
+public class IndraHttpClient {
+    private OkHttpClient client;
+    private HttpUrl endpoint;
+    private static final String JSON_CONTENT_TYPE = "application/json";
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.parse(JSON_CONTENT_TYPE);
+
+    /**
+     * Creates a new IndraHttpClient to communicate with the Indra server.
+     *
+     * @param endpoint The URL to the Indra server without path, e.g. "http://127.0.0.1:8916"
+     */
+    public IndraHttpClient(String endpoint) {
+        this.endpoint = HttpUrl.parse(endpoint);
+        this.client = new OkHttpClient();
+    }
+
+    /**
+     * Requests the relatedness between {@code TextPair}s from the endpoint.
+     *
+     * @param r RelatednessRequest Request containing the TextPairs.
+     * @return RelatednessResponse consisting of ScoredTextPairs, null if request was not successful.
+     * @throws IOException if the request could not be executed or response could not be parsed.
+     */
+    public RelatednessResponse Relatedness(RelatednessRequest r) throws IOException {
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        String json = mapper.writeValueAsString(r);
+        RequestBody body = RequestBody.create(JSON_MEDIA_TYPE, json);
+
+        Request request = new Request.Builder()
+                .url(this.endpoint.resolve("/relatedness"))
+                .addHeader("accept", JSON_CONTENT_TYPE)
+                .addHeader("content-type", JSON_CONTENT_TYPE)
+                .post(body)
+                .build();
+
+        RelatednessResponse resp = null;
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                resp = mapper.readValue(response.body().byteStream(), RelatednessResponse.class);
+            }
+        }
+        return resp;
+    }
+}

--- a/indra-client/src/test/java/org/lambda3/indra/client/IndraHttpClientTest.java
+++ b/indra-client/src/test/java/org/lambda3/indra/client/IndraHttpClientTest.java
@@ -1,0 +1,87 @@
+package org.lambda3.indra.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.lambda3.indra.common.client.*;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+/*-
+ * ==========================License-Start=============================
+ * Indra Core Module
+ * --------------------------------------------------------------------
+ * Copyright (C) 2016 - 2017 Lambda^3
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * ==========================License-End===============================
+ */
+
+public class IndraHttpClientTest {
+
+    @Test
+    public void RelatednessTest() throws Exception {
+
+        // Build the request
+        List<TextPair> reqTextPairs = new LinkedList<TextPair>() {{
+            add(new TextPair("mother", "love"));
+            add(new TextPair("father", "love"));
+        }};
+        RelatednessRequest request = new RelatednessRequest("wiki-2014", "W2V", "EN", reqTextPairs, ScoreFunction.COSINE);
+
+        // Mock the response
+        ObjectMapper mapper = new ObjectMapper();
+        RelatednessResponse mockResp = new RelatednessResponse();
+        mockResp.corpus = "wiki-2014";
+        mockResp.model = "W2V";
+        mockResp.language = "EN";
+        mockResp.scoreFunction = ScoreFunction.COSINE;
+        mockResp.pairs = new LinkedList<ScoredTextPair>() {{
+            add(new ScoredTextPair(new AnalyzedPair(new TextPair("mother", "love")), 0.9));
+            add(new ScoredTextPair(new AnalyzedPair(new TextPair("father", "love")), 0.3));
+        }};
+
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(mapper.writeValueAsString(mockResp)));
+
+        // Start the mock server.
+        server.start();
+
+        IndraHttpClient c = new IndraHttpClient(server.url("/").toString());
+
+        RelatednessResponse resp = c.Relatedness(request);
+        Collection<ScoredTextPair> pairse = resp.pairs;
+
+        // Test response unmarshalling
+        assertEquals(resp, mockResp);
+
+        // Test request path and body
+        RecordedRequest request1 = server.takeRequest();
+        assertEquals(request1.getPath(), "/relatedness");
+
+        RelatednessRequest gotReq = mapper.readValue(request1.getBody().inputStream(), RelatednessRequest.class);
+        assertEquals(gotReq, request);
+    }
+}

--- a/indra-common/pom.xml
+++ b/indra-common/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.lambda3</groupId>
         <artifactId>indra-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/indra-common/src/main/java/org/lambda3/indra/common/client/RelatednessRequest.java
+++ b/indra-common/src/main/java/org/lambda3/indra/common/client/RelatednessRequest.java
@@ -1,4 +1,4 @@
-package org.lambda3.indra.service.resources;
+package org.lambda3.indra.common.client;
 
 /*-
  * ==========================License-Start=============================
@@ -26,6 +26,7 @@ package org.lambda3.indra.service.resources;
  * ==========================License-End===============================
  */
 
+import com.sun.org.apache.regexp.internal.RE;
 import org.lambda3.indra.common.client.ScoreFunction;
 import org.lambda3.indra.common.client.TextPair;
 
@@ -39,6 +40,17 @@ public final class RelatednessRequest {
     public List<TextPair> pairs;
     public ScoreFunction scoreFunction;
 
+    public RelatednessRequest() {
+    }
+
+    public RelatednessRequest(String corpus, String model, String language, List<TextPair> pairs, ScoreFunction scoreFunction) {
+        this.corpus = corpus;
+        this.model = model;
+        this.language = language;
+        this.pairs = pairs;
+        this.scoreFunction = scoreFunction;
+    }
+
     @Override
     public String toString() {
         return "RelatednessRequest{" +
@@ -48,5 +60,29 @@ public final class RelatednessRequest {
                 ", pairs=" + pairs +
                 ", scoreFunction=" + scoreFunction +
                 '}';
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RelatednessRequest that = (RelatednessRequest) o;
+
+        if (corpus != null ? !corpus.equals(that.corpus) : that.corpus != null) return false;
+        if (model != null ? !model.equals(that.model) : that.model != null) return false;
+        if (language != null ? !language.equals(that.language) : that.language != null) return false;
+        if (pairs != null ? !pairs.equals(that.pairs) : that.pairs != null) return false;
+        return scoreFunction == that.scoreFunction;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = corpus != null ? corpus.hashCode() : 0;
+        result = 31 * result + (model != null ? model.hashCode() : 0);
+        result = 31 * result + (language != null ? language.hashCode() : 0);
+        result = 31 * result + (pairs != null ? pairs.hashCode() : 0);
+        result = 31 * result + (scoreFunction != null ? scoreFunction.hashCode() : 0);
+        return result;
     }
 }

--- a/indra-common/src/main/java/org/lambda3/indra/common/client/RelatednessResponse.java
+++ b/indra-common/src/main/java/org/lambda3/indra/common/client/RelatednessResponse.java
@@ -1,4 +1,4 @@
-package org.lambda3.indra.service.resources;
+package org.lambda3.indra.common.client;
 
 /*-
  * ==========================License-Start=============================
@@ -47,5 +47,29 @@ public final class RelatednessResponse {
                 ", pairs=" + pairs +
                 ", scoreFunction=" + scoreFunction +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RelatednessResponse that = (RelatednessResponse) o;
+
+        if (corpus != null ? !corpus.equals(that.corpus) : that.corpus != null) return false;
+        if (model != null ? !model.equals(that.model) : that.model != null) return false;
+        if (language != null ? !language.equals(that.language) : that.language != null) return false;
+        if (pairs != null ? !pairs.equals(that.pairs) : that.pairs != null) return false;
+        return scoreFunction == that.scoreFunction;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = corpus != null ? corpus.hashCode() : 0;
+        result = 31 * result + (model != null ? model.hashCode() : 0);
+        result = 31 * result + (language != null ? language.hashCode() : 0);
+        result = 31 * result + (pairs != null ? pairs.hashCode() : 0);
+        result = 31 * result + (scoreFunction != null ? scoreFunction.hashCode() : 0);
+        return result;
     }
 }

--- a/indra-core/pom.xml
+++ b/indra-core/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.lambda3</groupId>
         <artifactId>indra-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/indra-service/pom.xml
+++ b/indra-service/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.lambda3</groupId>
         <artifactId>indra-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/indra-service/src/main/java/org/lambda3/indra/service/impl/MockedRelatednessResourceImpl.java
+++ b/indra-service/src/main/java/org/lambda3/indra/service/impl/MockedRelatednessResourceImpl.java
@@ -28,9 +28,9 @@ package org.lambda3.indra.service.impl;
 
 import org.lambda3.indra.common.client.AnalyzedPair;
 import org.lambda3.indra.common.client.ScoredTextPair;
-import org.lambda3.indra.service.resources.RelatednessRequest;
+import org.lambda3.indra.common.client.RelatednessRequest;
 import org.lambda3.indra.service.resources.RelatednessResource;
-import org.lambda3.indra.service.resources.RelatednessResponse;
+import org.lambda3.indra.common.client.RelatednessResponse;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/indra-service/src/main/java/org/lambda3/indra/service/impl/RelatednessResourceImpl.java
+++ b/indra-service/src/main/java/org/lambda3/indra/service/impl/RelatednessResourceImpl.java
@@ -31,9 +31,9 @@ import org.lambda3.indra.core.RelatednessClient;
 import org.lambda3.indra.core.RelatednessResult;
 import org.lambda3.indra.core.RelatednessClientFactory;
 import org.lambda3.indra.core.VectorSpaceFactory;
-import org.lambda3.indra.service.resources.RelatednessRequest;
+import org.lambda3.indra.common.client.RelatednessRequest;
 import org.lambda3.indra.service.resources.RelatednessResource;
-import org.lambda3.indra.service.resources.RelatednessResponse;
+import org.lambda3.indra.common.client.RelatednessResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/indra-service/src/main/java/org/lambda3/indra/service/resources/RelatednessResource.java
+++ b/indra-service/src/main/java/org/lambda3/indra/service/resources/RelatednessResource.java
@@ -27,6 +27,9 @@ package org.lambda3.indra.service.resources;
  */
 
 
+import org.lambda3.indra.common.client.RelatednessRequest;
+import org.lambda3.indra.common.client.RelatednessResponse;
+
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.lambda3</groupId>
     <artifactId>indra-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Indra</name>
@@ -31,6 +31,7 @@
         <module>indra-service</module>
         <module>indra-core</module>
         <module>indra-common</module>
+        <module>indra-client</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
IndraHTTPClient can be used to communicate with the service endpoint via
HTTP.

Currently supports `Relatedness` requests.

Moving RelatednessRequest and RelatednessResponse to indra-common
to serve as the nexus between the indra-client and indra-service.

I incremented the PATCH version number, to avoid further breaking other projects. Unsure if you plan to use semver.